### PR TITLE
add server.js, missing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+    "scripts": {
+        "start": "node server.js"
+    },
+    "dependencies": {
+        "connect": "3.7.0",
+        "serve-static": "1.15.0"
+    }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,6 @@
+var connect = require('connect');
+var serveStatic = require('serve-static');
+
+connect()
+    .use(serveStatic(__dirname))
+    .listen(3000, () => console.log('Server running on 3000...'));


### PR DESCRIPTION
- Add 2 dependencies to package.json, run `npm install` to install them.
- Add a run script to package.json, run `npm start` to start the server, then go to http://localhost:3000/interface.html to access the html file.